### PR TITLE
Added an error handling event after uglify 

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -99,7 +99,7 @@ gulp.task('sass',['minify-css'], function () {
     return stream;
 });
 
-// Run: 
+// Run:
 // gulp watch
 // Starts watcher. Watcher runs gulp sass task on changes
 gulp.task('watch', function () {
@@ -117,7 +117,7 @@ gulp.task('imagemin', function(){
     .pipe(gulp.dest('img'))
 });
 
-// Run: 
+// Run:
 // gulp nanocss
 // Minifies CSS files
 gulp.task('cssnano', ['cleancss'], function(){
@@ -128,7 +128,7 @@ gulp.task('cssnano', ['cleancss'], function(){
     .pipe(cssnano({discardComments: {removeAll: true}}))
     .pipe(sourcemaps.write('./'))
     .pipe(gulp.dest('./css/'));
-}); 
+});
 
 gulp.task('minify-css', function() {
   return gulp.src('./css/child-theme.css')
@@ -139,25 +139,25 @@ gulp.task('minify-css', function() {
 });
 
 gulp.task('cleancss', function() {
-  return gulp.src('./css/*.min.css', { read: false }) // much faster 
+  return gulp.src('./css/*.min.css', { read: false }) // much faster
     .pipe(ignore('theme.css'))
     .pipe(rimraf());
 });
 
-// Run: 
+// Run:
 // gulp browser-sync
 // Starts browser-sync task for starting the server.
 gulp.task('browser-sync', function() {
     browserSync.init(browserSyncWatchFiles, browserSyncOptions);
 });
 
-// Run: 
+// Run:
 // gulp watch-bs
 // Starts watcher with browser-sync. Browser-sync reloads page automatically on your browser
 gulp.task('watch-bs', ['browser-sync', 'watch', 'minify-css'], function () { });
 
-// Run: 
-// gulp scripts. 
+// Run:
+// gulp scripts.
 // Uglifies and concat all JS files into one
 gulp.task('scripts', function() {
     var scripts = [
@@ -172,7 +172,9 @@ gulp.task('scripts', function() {
     ];
   gulp.src(scripts)
     .pipe(concat('child-theme.min.js'))
-    .pipe(uglify())
+    .pipe(uglify().on('error', function(e){
+            console.log(e);
+         }))
     .pipe(gulp.dest('./js/'));
 
   gulp.src(scripts)
@@ -185,16 +187,16 @@ gulp.task('clean-source', function () {
   return del(['src/**/*',]);
 });
 
-// Run: 
-// gulp copy-assets. 
+// Run:
+// gulp copy-assets.
 // Copy all needed dependency assets files from bower_component assets to themes /js, /scss and /fonts folder. Run this task after bower install or bower update
 
 
-// Copy all Bootstrap JS files 
+// Copy all Bootstrap JS files
 gulp.task('copy-assets', function() {
 
 ////////////////// All Bootstrap 4 Assets /////////////////////////
-// Copy all Bootstrap JS files 
+// Copy all Bootstrap JS files
     gulp.src(basePaths.node + 'bootstrap/dist/js/**/*.js')
        .pipe(gulp.dest(basePaths.dev + '/js/bootstrap4'));
 


### PR DESCRIPTION
When you edit JS files and by mistake break the structure, uglify can throw a non-resolvable error that stops the watch.  In order to prevent it, I added an error event that just console.logs the error.

