### PR TITLE
Fix gulp error trunk already filled on subsequent run

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -38,12 +38,11 @@ var sourcemaps = require('gulp-sourcemaps');
 var browserSync = require('browser-sync').create();
 var del = require('del');
 var cleanCSS = require('gulp-clean-css');
-var gulpSequence = require('gulp-sequence')
+var gulpSequence = require('gulp-sequence');
 
 function swallowError(self, error) {
-    console.log(error.toString())
-
-    self.emit('end')
+    console.log(error.toString());
+    self.emit('end');
 }
 
 // Run:
@@ -80,7 +79,7 @@ gulp.task('scss-for-dev', function() {
         .pipe(sourcemaps.init({loadMaps: true}))
         .pipe(sass())
         .pipe(sourcemaps.write(undefined, { sourceRoot: null }))
-        .pipe(gulp.dest('./css'))
+        .pipe(gulp.dest('./css'));
 });
 
 gulp.task('watch-scss', ['browser-sync'], function () {
@@ -100,7 +99,7 @@ gulp.task('sass', function () {
         }))
         .pipe(sass())
         .pipe(gulp.dest('./css'))
-        .pipe(rename('custom-editor-style.css'))
+        .pipe(rename('custom-editor-style.css'));
     return stream;
 });
 
@@ -118,7 +117,7 @@ gulp.task('watch', function () {
 gulp.task('imagemin', function(){
     gulp.src('img/src/**')
     .pipe(imagemin())
-    .pipe(gulp.dest('img'))
+    .pipe(gulp.dest('img'));
 });
 
 // Run:
@@ -259,7 +258,7 @@ gulp.task('copy-assets', function() {
 // Copies the files to the /dist folder for distributon
 gulp.task('dist', ['clean-dist'], function() {
     gulp.src(['**/*','!bower_components','!bower_components/**','!node_modules','!node_modules/**','!src','!src/**','!dist','!dist/**','!sass','!sass/**','!readme.txt','!readme.md','!package.json','!gulpfile.js','!CHANGELOG.md','!.travis.yml','!jshintignore', '!codesniffer.ruleset.xml', '*'])
-    .pipe(gulp.dest('dist/'))
+    .pipe(gulp.dest('dist/'));
 });
 
 // Deleting any file inside the /src folder
@@ -272,7 +271,7 @@ gulp.task('clean-dist', function () {
 // Copies the files to the /dist folder for distributon
 gulp.task('dist-product', ['clean-dist-product'], function() {
     gulp.src(['**/*','!bower_components','!bower_components/**','!node_modules','!node_modules/**','!dist','!dist/**', '*'])
-    .pipe(gulp.dest('dist-product/'))
+    .pipe(gulp.dest('dist-product/'));
 });
 
 // Deleting any file inside the /src folder

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -155,7 +155,9 @@ gulp.task('cleancss', function() {
     .pipe(rimraf());
 });
 
-gulp.task('styles', gulpSequence('sass', 'minify-css'))
+gulp.task('styles', function(callback) {
+    gulpSequence('sass', 'minify-css')(callback);
+});
 
 // Run:
 // gulp browser-sync


### PR DESCRIPTION
When running watch-bs an error occurs on subsequent runs.
Same is happening here: https://github.com/teambition/gulp-sequence/issues/2
Also added the missing semicolons, found by jshint.